### PR TITLE
Packet benchmarks and optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1156,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "thiserror",
+ "x25519-dalek 2.0.0",
 ]
 
 [[package]]
@@ -1239,6 +1267,12 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
 
 [[package]]
 name = "flume"
@@ -2233,6 +2267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "platforms"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,7 +3118,7 @@ dependencies = [
  "tachyonix",
  "thiserror",
  "tracing",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
 ]
 
 [[package]]
@@ -3750,8 +3790,20 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+dependencies = [
+ "curve25519-dalek 4.1.1",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,9 +1306,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "flume"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +672,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags 1.3.2",
+ "textwrap",
+ "unicode-width",
 ]
 
 [[package]]
@@ -759,6 +787,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +884,27 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -975,7 +1060,7 @@ dependencies = [
  "blake3",
  "bytemuck",
  "bytes",
- "clap",
+ "clap 4.4.8",
  "clone-macro",
  "concurrent-queue 2.3.0",
  "dashmap",
@@ -1037,6 +1122,7 @@ dependencies = [
  "bytes",
  "chacha20",
  "chacha20poly1305",
+ "criterion",
  "earendil_crypt",
  "ed25519-compact",
  "rand 0.8.5",
@@ -1389,6 +1475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1510,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1601,7 +1702,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
  "windows-sys",
 ]
@@ -1612,7 +1713,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "rustix 0.38.19",
  "windows-sys",
 ]
@@ -1919,7 +2020,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -1937,6 +2038,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -2124,6 +2231,34 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pod"
@@ -2330,6 +2465,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2600,6 +2755,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -3054,6 +3219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3110,6 +3284,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3222,7 +3406,7 @@ name = "udp-spammer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 4.4.8",
  "smol",
  "smolscale",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +964,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,7 +1150,7 @@ dependencies = [
  "base64",
  "blake3",
  "bytes",
- "ed25519-compact",
+ "ed25519-consensus",
  "rand 0.8.5",
  "serde",
  "stdcode",
@@ -1151,7 +1173,6 @@ dependencies = [
  "chacha20poly1305",
  "criterion",
  "earendil_crypt",
- "ed25519-compact",
  "rand 0.8.5",
  "serde",
  "serde-big-array",
@@ -1190,6 +1211,21 @@ checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
 dependencies = [
  "ct-codecs",
  "getrandom 0.2.10",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -2895,6 +2931,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3228,12 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,15 @@ base64 = "0.21.5"
 
 [profile.dev]
 panic = 'abort'
+opt-level = 1
 
 [profile.release]
 panic = 'abort'
 
 [profile.release-dbg]
+inherits = "release"
+debug = 2
+
+[profile.bench]
 inherits = "release"
 debug = 2

--- a/libraries/earendil_crypt/Cargo.toml
+++ b/libraries/earendil_crypt/Cargo.toml
@@ -11,9 +11,10 @@ arrayref = "0.3.7"
 base32 = "0.4.0"
 blake3 = "1.5.0"
 bytes = "1.5.0"
-ed25519-compact = "2.0.4"
+
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }
 stdcode = "0.1.14"
 thiserror = "1.0.49"
 base64 = "0.21.5"
+ed25519-consensus = "2.1.0"

--- a/libraries/earendil_packet/Cargo.toml
+++ b/libraries/earendil_packet/Cargo.toml
@@ -22,6 +22,7 @@ bs58 = "0.5.0"
 serde-big-array = "0.5.1"
 earendil_crypt = { path = "../earendil_crypt" }
 base64 = "0.21.5"
+x25519-dalek = {version="2.0.0", features=["reusable_secrets"]}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/libraries/earendil_packet/Cargo.toml
+++ b/libraries/earendil_packet/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck = { version = "1.14.0", features = ["derive", "min_const_generics"] }
 bytes = { version = "1.5.0", features = ["serde"] }
 chacha20 = "0.9.1"
 chacha20poly1305 = "0.10.1"
-ed25519-compact = "2.0.4"
+
 rand = "0.8.5"
 thiserror = "1.0.49"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -30,3 +30,6 @@ criterion = "0.3"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[profile.release]
+debug = true  # Include debug symbols in release builds

--- a/libraries/earendil_packet/Cargo.toml
+++ b/libraries/earendil_packet/Cargo.toml
@@ -23,3 +23,9 @@ serde-big-array = "0.5.1"
 earendil_crypt = { path = "../earendil_crypt" }
 base64 = "0.21.5"
 
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/libraries/earendil_packet/Cargo.toml
+++ b/libraries/earendil_packet/Cargo.toml
@@ -30,4 +30,3 @@ criterion = "0.3"
 [[bench]]
 name = "benchmark"
 harness = false
-

--- a/libraries/earendil_packet/Cargo.toml
+++ b/libraries/earendil_packet/Cargo.toml
@@ -31,5 +31,3 @@ criterion = "0.3"
 name = "benchmark"
 harness = false
 
-[profile.release]
-debug = true  # Include debug symbols in release builds

--- a/libraries/earendil_packet/benches/benchmark.rs
+++ b/libraries/earendil_packet/benches/benchmark.rs
@@ -1,0 +1,80 @@
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use earendil_crypt::{Fingerprint, IdentitySecret};
+use earendil_packet::{
+    crypt::OnionSecret, ForwardInstruction, InnerPacket, Message, RawPacket, ReplyBlock,
+};
+
+fn generate_forward_instructions(n: usize) -> Vec<(ForwardInstruction, OnionSecret)> {
+    (0..n)
+        .map(|_| {
+            let our_sk = OnionSecret::generate();
+            let this_pubkey = our_sk.public();
+
+            let next_fingerprint = Fingerprint::from_bytes(&[10; 20]);
+            (
+                ForwardInstruction {
+                    this_pubkey,
+                    next_fingerprint,
+                },
+                our_sk,
+            )
+        })
+        .collect()
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("generate an OnionSecret", |b| {
+        b.iter(|| {
+            black_box(OnionSecret::generate());
+        })
+    });
+
+    // RawPacket and ReplyBlock benchmarking
+    for route_length in [1, 4, 8] {
+        let route = generate_forward_instructions(route_length)
+            .into_iter()
+            .map(|s| s.0)
+            .collect::<Vec<_>>();
+        let destination_sk = OnionSecret::generate();
+        let destination = destination_sk.public();
+        let payload = InnerPacket::Message(Message {
+            source_dock: 0u32,
+            dest_dock: 0u32,
+            body: Bytes::from_static(b"hello world"),
+        });
+        let my_isk = IdentitySecret::generate();
+        let my_osk = OnionSecret::generate();
+        let my_opk = my_osk.public();
+
+        c.bench_function(&format!("{route_length}-hop RawPacket construction"), |b| {
+            b.iter(|| {
+                black_box(RawPacket::new_normal(
+                    &route,
+                    &destination,
+                    payload.clone(),
+                    &my_isk,
+                ))
+            });
+        });
+
+        let my_anon_osk = OnionSecret::generate();
+        let my_anon_isk = IdentitySecret::generate();
+        c.bench_function(
+            &format!("{route_length}-hop ReplyBlock construction"),
+            |b| {
+                b.iter(|| {
+                    black_box(ReplyBlock::new(
+                        &route,
+                        &my_opk,
+                        my_anon_osk.clone(),
+                        my_anon_isk.clone(),
+                    ))
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/libraries/earendil_packet/src/crypt.rs
+++ b/libraries/earendil_packet/src/crypt.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 /// An onion-routing public key, based on x25519.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct OnionPublic(ed25519_compact::x25519::PublicKey);
+pub struct OnionPublic(x25519_dalek::PublicKey);
 
 impl<'de> Deserialize<'de> for OnionPublic {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -36,12 +36,12 @@ impl Serialize for OnionPublic {
 impl OnionPublic {
     /// Return the bytes representation.
     pub fn as_bytes(&self) -> &[u8; 32] {
-        &self.0
+        self.0.as_bytes()
     }
 
     /// Construct an OnionPublic from bytes.
     pub fn from_bytes(bytes: &[u8; 32]) -> Self {
-        Self(ed25519_compact::x25519::PublicKey::new(*bytes))
+        Self(x25519_dalek::PublicKey::from(*bytes))
     }
 }
 
@@ -62,22 +62,24 @@ impl FromStr for OnionPublic {
 
 /// An onion-routing secret key, based on x25519.
 #[derive(Clone)]
-pub struct OnionSecret(ed25519_compact::x25519::KeyPair);
+pub struct OnionSecret(x25519_dalek::ReusableSecret);
 
 impl OnionSecret {
     /// Generates a secret key.
     pub fn generate() -> Self {
-        Self(ed25519_compact::x25519::KeyPair::generate())
+        Self(x25519_dalek::ReusableSecret::random_from_rng(
+            rand::thread_rng(),
+        ))
     }
 
     /// Returns the public key of this secret key.
     pub fn public(&self) -> OnionPublic {
-        OnionPublic(self.0.pk)
+        OnionPublic((&self.0).into())
     }
 
     /// Derive the shared secret, given somebody else's public key.
     pub fn shared_secret(&self, theirs: &OnionPublic) -> [u8; 32] {
-        theirs.0.dh(&self.0.sk).map(|d| *d).unwrap_or_default()
+        self.0.diffie_hellman(&theirs.0).to_bytes()
     }
 }
 

--- a/libraries/earendil_packet/src/crypt.rs
+++ b/libraries/earendil_packet/src/crypt.rs
@@ -61,6 +61,8 @@ impl FromStr for OnionPublic {
 }
 
 /// An onion-routing secret key, based on x25519.
+///
+/// This is *intentionally* not serializable, and we *intentionally* never expose the underlying bytes representation. This is to ensure we only use them as in-memory ephemeral or mid-term keys.
 #[derive(Clone)]
 pub struct OnionSecret(x25519_dalek::ReusableSecret);
 

--- a/libraries/earendil_packet/src/raw.rs
+++ b/libraries/earendil_packet/src/raw.rs
@@ -64,7 +64,7 @@ impl RawPacket {
         Ok(Self {
             header: reply_block.header,
             onion_body: payload
-                .seal(my_isk, &reply_block.e2e_dest)
+                .encode(my_isk)
                 .map_err(|_| PacketConstructError::MessageTooBig)?,
         })
     }
@@ -82,7 +82,7 @@ impl RawPacket {
         // Use a recursive algorithm. Base case: the route is empty
         if route.is_empty() {
             let sealed_payload = payload
-                .seal(my_isk, destination)
+                .encode(my_isk)
                 .map_err(|_| PacketConstructError::MessageTooBig)?;
             // Encrypt for the destination, so that when the destination peels, it receives a PeeledPacket::Receive
             let mut buffer = [0; 21];
@@ -190,7 +190,7 @@ impl RawPacket {
             let inner_metadata = *array_ref![metadata, 1, 20];
             // the remainder is all zeros. it means that this packet is ungarbled and a normal packet
             if inner_metadata == [0; 20] {
-                let (inner_pkt, fp) = InnerPacket::open(&peeled_body, our_sk)
+                let (inner_pkt, fp) = InnerPacket::decode(&peeled_body)
                     .map_err(|_| PacketPeelError::InnerPacketOpenError)?;
                 PeeledPacket::Received {
                     from: fp,

--- a/libraries/earendil_packet/src/reply_block.rs
+++ b/libraries/earendil_packet/src/reply_block.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     crypt::{stream_dencrypt, OnionPublic, OnionSecret},
-    ForwardInstruction, InnerPacket, Message, OpenError, PacketConstructError, RawHeader,
+    DecodeError, ForwardInstruction, InnerPacket, Message, PacketConstructError, RawHeader,
     RawPacket,
 };
 
@@ -65,12 +65,15 @@ pub struct ReplyDegarbler {
 }
 
 impl ReplyDegarbler {
-    pub fn degarble(&self, raw: &mut [u8; 8192]) -> Result<(InnerPacket, Fingerprint), OpenError> {
+    pub fn degarble(
+        &self,
+        raw: &mut [u8; 8192],
+    ) -> Result<(InnerPacket, Fingerprint), DecodeError> {
         for shared_sec in &self.shared_secs {
             let body_key = blake3::keyed_hash(b"body____________________________", shared_sec);
             stream_dencrypt(body_key.as_bytes(), &[0; 12], raw);
         }
-        InnerPacket::open(raw, &self.my_anon_osk)
+        InnerPacket::decode(raw)
     }
 
     pub fn my_anon_osk(&self) -> OnionSecret {

--- a/libraries/earendil_topology/Cargo.toml
+++ b/libraries/earendil_topology/Cargo.toml
@@ -23,3 +23,4 @@ rand = "0.8.5"
 indexmap = { version = "1.9.3", features = ["serde"] }
 thiserror= "1.0.49"
 earendil_crypt={path="../earendil_crypt"}
+

--- a/src/daemon/n2r_socket.rs
+++ b/src/daemon/n2r_socket.rs
@@ -128,7 +128,7 @@ impl FromStr for Endpoint {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let elems: Vec<&str> = s.split(":").collect();
+        let elems: Vec<&str> = s.split(':').collect();
         if elems.len() != 2 {
             return Err(anyhow::anyhow!(
                 "Wrong endpoint format! Endpoint format should be fingerprint:dock"

--- a/src/daemon/udp_forward.rs
+++ b/src/daemon/udp_forward.rs
@@ -66,11 +66,7 @@ pub async fn udp_forward_loop(
             let down_loop = Immortal::respawn(
                 smolscale::immortal::RespawnStrategy::Immediate,
                 clone!([earendil_skt, udp_socket], move || {
-                    down_loop(
-                        earendil_skt.clone(),
-                        udp_socket.clone(),
-                        src_udp_addr.clone(),
-                    )
+                    down_loop(earendil_skt.clone(), udp_socket.clone(), src_udp_addr)
                 }),
             );
             (earendil_skt, Arc::new(down_loop))

--- a/utilities/udp-spammer/src/main.rs
+++ b/utilities/udp-spammer/src/main.rs
@@ -50,10 +50,6 @@ fn main() {
 }
 
 async fn uspammer_client(rate: u64, server: SocketAddr) -> anyhow::Result<()> {
-    if rate <= 0 {
-        anyhow::bail!("rate must be positive")
-    }
-
     let start_time = Instant::now();
     let skt = UdpSocket::bind("0.0.0.0:0").await?;
 


### PR DESCRIPTION
- `criterion` benchmarks are added to `earendil_packet`
- moved x25519 to `x25519-dalek` and ed25519 to `ed25519-consensus`
- removed pointless source authentication for N2R messages

All this together shows a significant improvement in performance, especially for single-hop routes:

```
generate an OnionSecret time:   [38.610 ns 38.621 ns 38.636 ns]                                     
                        change: [-99.934% -99.932% -99.931%] (p = 0.00 < 0.05)
                        Performance has improved.

1-hop RawPacket construction                                                                            
                        time:   [298.87 µs 299.14 µs 299.48 µs]
                        change: [-65.115% -63.156% -61.351%] (p = 0.00 < 0.05)
                        Performance has improved.

1-hop ReplyBlock construction                                                                            
                        time:   [320.77 µs 320.81 µs 320.85 µs]
                        change: [-52.486% -52.441% -52.396%] (p = 0.00 < 0.05)
                        Performance has improved.

4-hop RawPacket construction                                                                            
                        time:   [709.19 µs 709.40 µs 709.76 µs]
                        change: [-38.414% -38.384% -38.352%] (p = 0.00 < 0.05)
                        Performance has improved.

4-hop ReplyBlock construction                                                                            
                        time:   [740.20 µs 740.73 µs 741.34 µs]
                        change: [-36.529% -36.461% -36.387%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking 8-hop RawPacket construction: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.5s, enable flat sampling, or reduce sample count to 60.
8-hop RawPacket construction                                                                             
                        time:   [1.2833 ms 1.2841 ms 1.2849 ms]
                        change: [-28.369% -28.322% -28.278%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking 8-hop ReplyBlock construction: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.5s, enable flat sampling, or reduce sample count to 60.
8-hop ReplyBlock construction                                                                             
                        time:   [1.2743 ms 1.2748 ms 1.2754 ms]
                        change: [-30.000% -29.913% -29.798%] (p = 0.00 < 0.05)
                        Performance has improved.
 ```