### PR TITLE
Simple proxy and socks5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "smol",
  "smol-timeout",
  "smolscale",
+ "socksv5",
  "sosistab2",
  "sosistab2-obfsudp",
  "stdcode",
@@ -3015,6 +3016,17 @@ checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socksv5"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc0d3f4727eeea5226189bf99d225b3f496d1379305c492f2af06adfeb8a51"
+dependencies = [
+ "byteorder",
+ "futures",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ moro = "0.4.0"
 replay_filter = "0.1.2"
 once_cell = "1.18.0"
 sosistab2-obfsudp = "0.1.11"
+socksv5 = "0.3.1"
 
 [profile.dev]
 panic = 'abort'

--- a/cfg_example/alice.yaml
+++ b/cfg_example/alice.yaml
@@ -18,8 +18,8 @@ tcp_forwards:
   - forward_to: 8081
     remote_ep: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:69421
 
-# socks5:
-#   port: 1000
-#   fallback: 
-#     simple_proxy:
-#       remote_ep: fhsg3742bwxmg3k14jdsbphdp22j119f:69422
+socks5:
+  listen_port: 8082
+  fallback: 
+    simple_proxy:
+      remote_ep: jm21nbaf4c8ejg25yq9mc7bg6sdeksja:69422

--- a/cfg_example/bob.yaml
+++ b/cfg_example/bob.yaml
@@ -19,10 +19,18 @@ havens:
       type: udp_forward
       from_dock: 69420
       to_port: 8814 # e.g. listening port of geph4-exit
+
   # fingerprint: pm3atrnq6awfp96qrjg5rmxp39d1bqfh
   - identity_seed: TCP_haven
     rendezvous: 0k28pjf5qa8nwbt7cn8138xetxdknhz3
     handler:
       type: tcp_forward
       from_dock: 69421
-      to_port: 8815 # e.g. listening port of geph4-exit
+      to_port: 8815
+
+  # fingerprint: jm21nbaf4c8ejg25yq9mc7bg6sdeksja
+  - identity_seed: simple_proxy_haven
+    rendezvous: 0k28pjf5qa8nwbt7cn8138xetxdknhz3
+    handler:
+      type: simple_proxy
+      listen_dock: 69422

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,7 @@ pub struct TcpForwardConfig {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Socks5 {
-    pub port: u16,
+    pub listen_port: u16,
     pub fallback: Fallback,
 }
 

--- a/src/daemon/context.rs
+++ b/src/daemon/context.rs
@@ -27,7 +27,6 @@ use crate::{
     global_rpc::{transport::GlobalRpcTransport, GlobalRpcClient},
     haven::HavenLocator,
     socket::Endpoint,
-    utils::get_or_create_id,
 };
 
 use super::{neightable::NeighTable, reply_block_store::ReplyBlockStore};

--- a/src/daemon/socks5.rs
+++ b/src/daemon/socks5.rs
@@ -1,0 +1,106 @@
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
+    str::FromStr,
+};
+
+use anyhow::Context;
+use earendil_crypt::Fingerprint;
+use futures_util::io;
+use smol::{
+    future::FutureExt,
+    net::{TcpListener, TcpStream},
+};
+use smolscale::reaper::TaskReaper;
+use socksv5::v5::*;
+
+use crate::{
+    config::{Fallback, Socks5},
+    socket::{Endpoint, Socket},
+    stream::Stream,
+};
+
+use super::DaemonContext;
+
+pub async fn socks5_loop(ctx: DaemonContext, socks5_cfg: Socks5) -> anyhow::Result<()> {
+    log::debug!("socks5 loop");
+    let tcp_listener = TcpListener::bind(SocketAddrV4::new(
+        "127.0.0.1".parse()?,
+        socks5_cfg.listen_port,
+    ))
+    .await?;
+    let fallback = socks5_cfg.fallback;
+    let reaper = TaskReaper::new();
+
+    loop {
+        let ctx = ctx.clone();
+        let fallback = fallback.clone();
+        let (tcp_stream, _) = tcp_listener.accept().await?;
+
+        reaper.attach(smol::spawn(async move {
+            tcp_stream.set_nodelay(true)?;
+            let _handshake = read_handshake(tcp_stream.clone()).await?;
+            write_auth_method(tcp_stream.clone(), SocksV5AuthMethod::Noauth).await?;
+            let request = read_request(tcp_stream.clone()).await?;
+            let port = request.port;
+            let domain: String = match &request.host {
+                SocksV5Host::Domain(dom) => String::from_utf8_lossy(dom).parse()?,
+                SocksV5Host::Ipv4(v4) => {
+                    let v4addr = Ipv4Addr::new(v4[0], v4[1], v4[2], v4[3]);
+                    v4addr.to_string()
+                }
+                _ => anyhow::bail!("IPv6 not supported"),
+            };
+            log::info!("socks5 received request for {domain}:{port}");
+
+            let mut split_domain = domain.split('.');
+            let top_level = split_domain.clone().last();
+            if let Some(top) = top_level {
+                if top == "haven" {
+                    let endpoint = Endpoint::new(
+                        Fingerprint::from_str(
+                            split_domain.next().context("invalid Earendil address")?,
+                        )?,
+                        port.into(),
+                    );
+                    let earendil_skt =
+                        Socket::bind_haven_internal(ctx.clone(), ctx.identity, None, None);
+                    let earendil_stream = Stream::connect(earendil_skt, endpoint).await?;
+
+                    io::copy(tcp_stream.clone(), &mut earendil_stream.clone())
+                        .race(io::copy(earendil_stream.clone(), &mut tcp_stream.clone()))
+                        .await?;
+                } else {
+                    match fallback {
+                        Fallback::Block => return Ok(()),
+                        Fallback::PassThrough => {
+                            let addr = format!("{domain}{port}");
+                            let mut addrs: Vec<SocketAddr> = addr.to_socket_addrs()?.collect();
+                            let passthrough_stream = TcpStream::connect(addrs.pop().context(
+                                format!("unable to resolve passthrough address {addr}"),
+                            )?)
+                            .await?;
+
+                            io::copy(tcp_stream.clone(), &mut passthrough_stream.clone())
+                                .race(io::copy(
+                                    passthrough_stream.clone(),
+                                    &mut tcp_stream.clone(),
+                                ))
+                                .await?;
+                        }
+                        Fallback::SimpleProxy { remote_ep } => {
+                            let proxy_skt =
+                                Socket::bind_haven_internal(ctx.clone(), ctx.identity, None, None);
+                            let proxy_stream = Stream::connect(proxy_skt, remote_ep).await?;
+
+                            io::copy(tcp_stream.clone(), &mut proxy_stream.clone())
+                                .race(io::copy(proxy_stream.clone(), &mut tcp_stream.clone()))
+                                .await?;
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }));
+    }
+}

--- a/src/daemon/socks5.rs
+++ b/src/daemon/socks5.rs
@@ -94,7 +94,9 @@ pub async fn socks5_loop(ctx: DaemonContext, socks5_cfg: Socks5) -> anyhow::Resu
                             let mut proxy_stream = Stream::connect(proxy_skt, remote_ep).await?;
                             let prepend = (domain.len() as u16).to_be_bytes();
                             proxy_stream.write(&prepend).await?;
-                            proxy_stream.write(domain.as_bytes()).await?;
+
+                            let addr = format!("{}:{}", domain, port);
+                            proxy_stream.write(addr.as_bytes()).await?;
 
                             io::copy(tcp_stream.clone(), &mut proxy_stream.clone())
                                 .race(io::copy(proxy_stream.clone(), &mut tcp_stream.clone()))

--- a/src/daemon/socks5.rs
+++ b/src/daemon/socks5.rs
@@ -88,12 +88,7 @@ pub async fn socks5_loop(ctx: DaemonContext, socks5_cfg: Socks5) -> anyhow::Resu
                     match fallback {
                         Fallback::Block => return Ok(()),
                         Fallback::PassThrough => {
-                            let mut addrs: Vec<SocketAddr> = addr.to_socket_addrs()?.collect();
-                            let passthrough_stream = TcpStream::connect(addrs.pop().context(
-                                format!("unable to resolve passthrough address {addr}"),
-                            )?)
-                            .await?;
-
+                            let passthrough_stream = TcpStream::connect(addr).await?;
                             io::copy(client_stream.clone(), &mut passthrough_stream.clone())
                                 .race(io::copy(
                                     passthrough_stream.clone(),

--- a/src/haven.rs
+++ b/src/haven.rs
@@ -133,6 +133,10 @@ async fn simple_proxy(
         &haven_cfg.identity_seed,
         "identity_kdf_salt",
     ));
+    log::info!(
+        "simple proxy haven fingerprint: {}",
+        haven_id.public().fingerprint()
+    );
 
     let earendil_skt = Socket::bind_haven_internal(
         ctx.clone(),
@@ -199,7 +203,10 @@ async fn udp_forward(ctx: DaemonContext, haven_cfg: HavenForwardConfig) -> anyho
         &haven_cfg.identity_seed,
         "identity_kdf_salt",
     ));
-    log::info!("haven fingerprint: {}", haven_id.public().fingerprint());
+    log::info!(
+        "UDP forward haven fingerprint: {}",
+        haven_id.public().fingerprint()
+    );
 
     let earendil_skt = Arc::new(Socket::bind_haven_internal(
         ctx.clone(),
@@ -245,7 +252,10 @@ async fn tcp_forward(ctx: DaemonContext, haven_cfg: HavenForwardConfig) -> anyho
         &haven_cfg.identity_seed,
         "identity_kdf_salt",
     ));
-    log::info!("haven fingerprint: {}", haven_id.public().fingerprint());
+    log::info!(
+        "TCP forward haven fingerprint: {}",
+        haven_id.public().fingerprint()
+    );
 
     let earendil_skt = Socket::bind_haven_internal(
         ctx.clone(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,3 +28,10 @@ pub fn get_or_create_id(path: &Path) -> anyhow::Result<IdentitySecret> {
         }
     }
 }
+
+pub fn id_from_seed(id_seed: &str) -> IdentitySecret {
+    IdentitySecret::from_bytes(&earendil_crypt::kdf_from_human(
+        id_seed,
+        "identity_kdf_salt",
+    ))
+}


### PR DESCRIPTION
# simple-proxy haven support and socks5 localhost server
* add built-in haven handler that serves a simple proxy server, which facilitates configuring and using simple TCP proxies over Earendil (this makes “browse the Internet over Earendil” much easier)
* add socks5 localhost server
  * If the hostname cannot be interpreted as an Earendil endpoint (because it doesn’t end in .haven), then we fallback:
    * `block` blocks the connection
    * `passthrough` connects to that hostname and port normally through TcpStream (this lets people just browse the internet normally if they’re not going to .haven addresses)
    * `simple-proxy` establishes an Earendil stream to the given fingerprint and dock, signals the hostname using simple-proxy