### PR TITLE
Rename options in config

### DIFF
--- a/cfg_example/alice-rob-bob/alice.yaml
+++ b/cfg_example/alice-rob-bob/alice.yaml
@@ -2,7 +2,6 @@ identity_seed: alice-was-here
 state_cache: alice_state_cache.db
 control_listen: 127.0.0.1:22222
 
-
 # in_routes:
 #   # arbitrary names, used for diagnositics and logging
 #   main_udp:
@@ -18,17 +17,16 @@ out_routes:
     cookie: 11deaee1eb5b796e416d54ad56522083938ea38218e8e7ea00e7466a04b5b750
 
 # udp_forwards:
-#   - forward_to: 8080
-#     remote_ep: v7c854h336wtphnk0eqjrydexmffvhgb:69420
+#   - listen: 127.0.0.1:8080
+#     remote: v7c854h336wtphnk0eqjrydexmffvhgb:69420
 
 tcp_forwards:
-  - forward_to: 8081
-    # remote_ep: v7c854h336wtphnk0eqjrydexmffvhgb:69421 # this has to be bob??
-    # remote_ep: ar8rfz3mp32m8ffkh86q258kq21j9abk:69421 # this has to be rob??
-    remote_ep: yqem5bc2m218hqzdk01wbdak42ky715e:69421
-
+  - listen: 127.0.0.1:8081
+    # remote: v7c854h336wtphnk0eqjrydexmffvhgb:69421 # this has to be bob??
+    # remote: ar8rfz3mp32m8ffkh86q258kq21j9abk:69421 # this has to be rob??
+    remote: yqem5bc2m218hqzdk01wbdak42ky715e:69421
 # socks5:
 #   port: 1000
-#   fallback: 
+#   fallback:
 #     simple_proxy:
 

--- a/cfg_example/alice-rob-bob/bob.yaml
+++ b/cfg_example/alice-rob-bob/bob.yaml
@@ -16,13 +16,13 @@ havens:
   #   rendezvous: 91fbz7f7b2fwy0xrvsyqqbwbmmqytdnr
   #   handler:
   #     type: udp_forward
-  #     from_dock: 69420
-  #     to_port: 8814 # e.g. listening port of geph4-exit
+  #     listen_dock: 69420
+  #     upstream: 127.0.0.1:8814 # e.g. listening port of geph4-exit
   #
   # haven fingerprint: vtcwz1tvpgp7ccxzepmw0evb6cpa09t7
   - identity_seed: i-am-a-haven-pls-no-eat-me
     rendezvous: q29wsm1jpvg6j494kfdyf3wad5m92331 # rob's fingerprint
     handler:
       type: tcp_forward
-      from_dock: 69421
-      to_port: 8815 # e.g. listening port of geph4-exit
+      listen_dock: 69421
+      upstream: 127.0.0.1:8815 # e.g. listening port of geph4-exit

--- a/cfg_example/alice.yaml
+++ b/cfg_example/alice.yaml
@@ -11,15 +11,15 @@ in_routes:
 
 # client config
 udp_forwards:
-  - forward_to: 8080
-    remote_ep: sge818x6f87yk3q2w7mrfjtgn0p67tja:69420
+  - listen: 127.0.0.1:8080
+    remote: sge818x6f87yk3q2w7mrfjtgn0p67tja:69420
 
 tcp_forwards:
-  - forward_to: 8081
-    remote_ep: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:69421
+  - listen: 127.0.0.1:8081
+    remote: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:69421
 
 socks5:
   listen_port: 8082
-  fallback: 
+  fallback:
     simple_proxy:
-      remote_ep: jm21nbaf4c8ejg25yq9mc7bg6sdeksja:69422
+      remote: jm21nbaf4c8ejg25yq9mc7bg6sdeksja:69422

--- a/cfg_example/bob.yaml
+++ b/cfg_example/bob.yaml
@@ -17,16 +17,16 @@ havens:
     rendezvous: 0k28pjf5qa8nwbt7cn8138xetxdknhz3
     handler:
       type: udp_forward
-      from_dock: 69420
-      to_port: 8814 # e.g. listening port of geph4-exit
+      listen_dock: 69420
+      upstream: 127.0.0.1:8814 # e.g. listening port of geph4-exit
 
   # fingerprint: pm3atrnq6awfp96qrjg5rmxp39d1bqfh
   - identity_seed: TCP_haven
     rendezvous: 0k28pjf5qa8nwbt7cn8138xetxdknhz3
     handler:
       type: tcp_forward
-      from_dock: 69421
-      to_port: 8815
+      listen_dock: 69421
+      upstream: 127.0.0.1:8815
 
   # fingerprint: jm21nbaf4c8ejg25yq9mc7bg6sdeksja
   - identity_seed: simple_proxy_haven

--- a/cfg_example/self-haven/self-haven.yaml
+++ b/cfg_example/self-haven/self-haven.yaml
@@ -10,8 +10,8 @@ in_routes:
 
 # client config
 udp_forwards:
-  - forward_to: 8080
-    remote_ep: cxvc52ndnzvy2kq1x9ajr2ft0tn5wk6n:10000
+  - listen: 127.0.0.1:8080
+    remote: cxvc52ndnzvy2kq1x9ajr2ft0tn5wk6n:10000
 
 # server config
 havens:
@@ -19,5 +19,5 @@ havens:
     rendezvous: bnjmrmw1kvjf7jmx5fa6a9x1hjtq7qh3
     handler:
       type: udp_forward
-      from_dock: 10000
-      to_port: 10000
+      listen_dock: 10000
+      upstream: 127.0.0.1:10000

--- a/local-tests/max-hop/judy.yaml
+++ b/local-tests/max-hop/judy.yaml
@@ -16,9 +16,9 @@ havens:
     rendezvous: 7wrkhwar5kj3hybwaf9pe996eydzc969 # alice
     handler:
       type: tcp_forward
-      from_dock: 6666
-      to_port: 8888
+      listen_dock: 6666
+      upstream: 127.0.0.1:8888
 
 tcp_forwards:
-  - forward_to: 4444
-    remote_ep: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:6666
+  - listen: 127.0.0.1:4444
+    remote: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:6666

--- a/shadow-tests/stream/configs/hosts/alice/alice.yaml
+++ b/shadow-tests/stream/configs/hosts/alice/alice.yaml
@@ -10,5 +10,5 @@ in_routes:
     secret: correct horse battery staple
 
 tcp_forwards:
-  - forward_to: 4444
-    remote_ep: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:69421
+  - listen: 127.0.0.1:4444
+    remote: pm3atrnq6awfp96qrjg5rmxp39d1bqfh:69421

--- a/shadow-tests/stream/configs/hosts/bob/bob.yaml
+++ b/shadow-tests/stream/configs/hosts/bob/bob.yaml
@@ -17,5 +17,5 @@ havens:
     rendezvous: 0k28pjf5qa8nwbt7cn8138xetxdknhz3
     handler:
       type: tcp_forward
-      from_dock: 69421
-      to_port: 8888
+      listen_dock: 69421
+      upstream: 127.0.0.1:8888

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,7 @@ pub struct HavenForwardConfig {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ForwardHandler {
-    UdpForward { from_dock: Dock, to_port: u16 },
-    TcpForward { from_dock: Dock, to_port: u16 },
+    UdpService { listen: Dock, upstream: SocketAddr },
+    TcpService { listen: Dock, upstream: SocketAddr },
     SimpleProxy { listen_dock: Dock },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,15 @@ pub struct HavenForwardConfig {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ForwardHandler {
-    UdpService { listen: Dock, upstream: SocketAddr },
-    TcpService { listen: Dock, upstream: SocketAddr },
-    SimpleProxy { listen_dock: Dock },
+    UdpService {
+        listen_dock: Dock,
+        upstream: SocketAddr,
+    },
+    TcpService {
+        listen_dock: Dock,
+        upstream: SocketAddr,
+    },
+    SimpleProxy {
+        listen_dock: Dock,
+    },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,7 @@ pub struct TcpForwardConfig {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Socks5 {
-    pub listen_port: u16,
+    pub listen: SocketAddr,
     pub fallback: Fallback,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,18 +71,18 @@ pub enum OutRouteConfig {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct UdpForwardConfig {
-    pub forward_to: u16,
+    pub listen: SocketAddr,
     #[serde_as(as = "serde_with::DisplayFromStr")]
-    pub remote_ep: Endpoint,
+    pub remote: Endpoint,
 }
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct TcpForwardConfig {
-    pub forward_to: u16,
+    pub listen: SocketAddr,
     #[serde_as(as = "serde_with::DisplayFromStr")]
-    pub remote_ep: Endpoint,
+    pub remote: Endpoint,
 }
 
 #[serde_as]
@@ -101,7 +101,7 @@ pub enum Fallback {
     PassThrough,
     SimpleProxy {
         #[serde_as(as = "serde_with::DisplayFromStr")]
-        remote_ep: Endpoint,
+        remote: Endpoint,
     },
 }
 

--- a/src/daemon/control_protocol_impl.rs
+++ b/src/daemon/control_protocol_impl.rs
@@ -85,19 +85,19 @@ impl ControlProtocol for ControlProtocolImpl {
                 .public()
                 .fingerprint();
                 match haven_cfg.handler {
-                    crate::config::ForwardHandler::UdpForward {
-                        from_dock,
-                        to_port: _,
+                    crate::config::ForwardHandler::UdpService {
+                        listen,
+                        upstream: _,
                     } => (
-                        "UdpForward".to_string(),
-                        fp.to_string() + ":" + &from_dock.to_string(),
+                        "UdpService".to_string(),
+                        fp.to_string() + ":" + &listen.to_string(),
                     ),
-                    crate::config::ForwardHandler::TcpForward {
-                        from_dock,
-                        to_port: _,
+                    crate::config::ForwardHandler::TcpService {
+                        listen,
+                        upstream: _,
                     } => (
-                        "TcpForward".to_string(),
-                        fp.to_string() + ":" + &from_dock.to_string(),
+                        "TcpService".to_string(),
+                        fp.to_string() + ":" + &listen.to_string(),
                     ),
                     crate::config::ForwardHandler::SimpleProxy { listen_dock } => (
                         "SimpleProxy".to_string(),

--- a/src/daemon/control_protocol_impl.rs
+++ b/src/daemon/control_protocol_impl.rs
@@ -86,18 +86,18 @@ impl ControlProtocol for ControlProtocolImpl {
                 .fingerprint();
                 match haven_cfg.handler {
                     crate::config::ForwardHandler::UdpService {
-                        listen,
+                        listen_dock,
                         upstream: _,
                     } => (
                         "UdpService".to_string(),
-                        fp.to_string() + ":" + &listen.to_string(),
+                        fp.to_string() + ":" + &listen_dock.to_string(),
                     ),
                     crate::config::ForwardHandler::TcpService {
-                        listen,
+                        listen_dock,
                         upstream: _,
                     } => (
                         "TcpService".to_string(),
-                        fp.to_string() + ":" + &listen.to_string(),
+                        fp.to_string() + ":" + &listen_dock.to_string(),
                     ),
                     crate::config::ForwardHandler::SimpleProxy { listen_dock } => (
                         "SimpleProxy".to_string(),

--- a/src/daemon/socks5.rs
+++ b/src/daemon/socks5.rs
@@ -103,7 +103,7 @@ async fn socks5_once(
                         ))
                         .await?;
                 }
-                Fallback::SimpleProxy { remote_ep } => {
+                Fallback::SimpleProxy { remote: remote_ep } => {
                     let remote_skt = Socket::bind_haven_internal(
                         ctx.clone(),
                         IdentitySecret::generate(),

--- a/src/daemon/socks5.rs
+++ b/src/daemon/socks5.rs
@@ -1,7 +1,4 @@
-use std::{
-    net::{Ipv4Addr, SocketAddrV4},
-    str::FromStr,
-};
+use std::{net::Ipv4Addr, str::FromStr};
 
 use anyhow::Context;
 use earendil_crypt::{Fingerprint, IdentitySecret};
@@ -24,11 +21,7 @@ use super::DaemonContext;
 
 pub async fn socks5_loop(ctx: DaemonContext, socks5_cfg: Socks5) -> anyhow::Result<()> {
     log::debug!("socks5 loop started");
-    let tcp_listener = TcpListener::bind(SocketAddrV4::new(
-        "127.0.0.1".parse()?,
-        socks5_cfg.listen_port,
-    ))
-    .await?;
+    let tcp_listener = TcpListener::bind(socks5_cfg.listen).await?;
     let fallback = socks5_cfg.fallback;
     let reaper = TaskReaper::new();
 
@@ -103,14 +96,14 @@ async fn socks5_once(
                         ))
                         .await?;
                 }
-                Fallback::SimpleProxy { remote: remote_ep } => {
+                Fallback::SimpleProxy { remote: remote } => {
                     let remote_skt = Socket::bind_haven_internal(
                         ctx.clone(),
                         IdentitySecret::generate(),
                         None,
                         None,
                     );
-                    let mut remote_stream = Stream::connect(remote_skt, remote_ep).await?;
+                    let mut remote_stream = Stream::connect(remote_skt, remote).await?;
                     let prepend = (addr.len() as u16).to_be_bytes();
                     remote_stream.write(&prepend).await?;
 

--- a/src/daemon/tcp_forward.rs
+++ b/src/daemon/tcp_forward.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddrV4;
-
 use earendil_crypt::IdentitySecret;
 use futures_util::io;
 use smol::{future::FutureExt, net::TcpListener};
@@ -14,18 +12,14 @@ pub async fn tcp_forward_loop(
     tcp_fwd_cfg: TcpForwardConfig,
 ) -> anyhow::Result<()> {
     log::debug!("tcp forward loop");
-    let tcp_listener = TcpListener::bind(SocketAddrV4::new(
-        "127.0.0.1".parse()?,
-        tcp_fwd_cfg.forward_to,
-    ))
-    .await?;
+    let tcp_listener = TcpListener::bind(tcp_fwd_cfg.listen).await?;
     let reaper = TaskReaper::new();
 
     loop {
         let (tcp_stream, _) = tcp_listener.accept().await?;
         let earendil_socket =
             Socket::bind_haven_internal(ctx.clone(), IdentitySecret::generate(), None, None);
-        let earendil_stream = Stream::connect(earendil_socket, tcp_fwd_cfg.remote_ep).await?;
+        let earendil_stream = Stream::connect(earendil_socket, tcp_fwd_cfg.remote).await?;
         reaper.attach(smolscale::spawn(async move {
             io::copy(tcp_stream.clone(), &mut earendil_stream.clone())
                 .race(io::copy(earendil_stream.clone(), &mut tcp_stream.clone()))

--- a/src/daemon/udp_forward.rs
+++ b/src/daemon/udp_forward.rs
@@ -1,8 +1,4 @@
-use std::{
-    net::{SocketAddr, SocketAddrV4},
-    sync::Arc,
-    time::Duration,
-};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use clone_macro::clone;
 use earendil_crypt::IdentitySecret;
@@ -33,13 +29,7 @@ pub async fn udp_forward_loop(
     let demux_table: Cache<SocketAddr, (Arc<Socket>, Arc<Immortal>)> = CacheBuilder::default()
         .time_to_idle(Duration::from_secs(60 * 60))
         .build();
-    let udp_socket = Arc::new(
-        UdpSocket::bind(SocketAddrV4::new(
-            "127.0.0.1".parse()?,
-            udp_fwd_cfg.forward_to,
-        ))
-        .await?,
-    );
+    let udp_socket = Arc::new(UdpSocket::bind(udp_fwd_cfg.listen).await?);
     let mut buf = [0; 10_000];
 
     loop {
@@ -70,7 +60,7 @@ pub async fn udp_forward_loop(
         // using the earendil socket associated with the src_udp_addr
         src_earendil_skt
             .0
-            .send_to(msg.into(), udp_fwd_cfg.remote_ep)
+            .send_to(msg.into(), udp_fwd_cfg.remote)
             .await?;
     }
 }

--- a/src/haven_util.rs
+++ b/src/haven_util.rs
@@ -109,13 +109,13 @@ impl RegisterHavenReq {
 pub async fn haven_loop(ctx: DaemonContext, haven_cfg: HavenForwardConfig) -> anyhow::Result<()> {
     match haven_cfg.handler {
         ForwardHandler::UdpService {
-            listen_dock: from_dock,
+            listen_dock: listen_dock,
             upstream,
-        } => udp_forward(ctx, haven_cfg, from_dock, upstream).await,
+        } => udp_forward(ctx, haven_cfg, listen_dock, upstream).await,
         ForwardHandler::TcpService {
-            listen_dock: from_dock,
+            listen_dock: listen_dock,
             upstream,
-        } => tcp_forward(ctx, haven_cfg, from_dock, upstream).await,
+        } => tcp_forward(ctx, haven_cfg, listen_dock, upstream).await,
         ForwardHandler::SimpleProxy { listen_dock } => {
             simple_proxy(ctx, haven_cfg, listen_dock).await
         }
@@ -125,7 +125,7 @@ pub async fn haven_loop(ctx: DaemonContext, haven_cfg: HavenForwardConfig) -> an
 async fn udp_forward(
     ctx: DaemonContext,
     haven_cfg: HavenForwardConfig,
-    from_dock: Dock,
+    listen_dock: Dock,
     upstream: SocketAddr,
 ) -> anyhow::Result<()> {
     // down loop forwards packets back down to the source Earendil endpoints
@@ -151,7 +151,7 @@ async fn udp_forward(
     let earendil_skt = Arc::new(Socket::bind_haven_internal(
         ctx.clone(),
         haven_id,
-        Some(from_dock),
+        Some(listen_dock),
         Some(haven_cfg.rendezvous),
     ));
     let dmux_table: Cache<Endpoint, (Arc<UdpSocket>, Arc<Immortal>)> = CacheBuilder::default()
@@ -183,7 +183,7 @@ async fn udp_forward(
 async fn tcp_forward(
     ctx: DaemonContext,
     haven_cfg: HavenForwardConfig,
-    from_dock: Dock,
+    listen_dock: Dock,
     upstream: SocketAddr,
 ) -> anyhow::Result<()> {
     let haven_id = IdentitySecret::from_seed(&haven_cfg.identity_seed);
@@ -195,7 +195,7 @@ async fn tcp_forward(
     let earendil_skt = Socket::bind_haven_internal(
         ctx.clone(),
         haven_id,
-        Some(from_dock),
+        Some(listen_dock),
         Some(haven_cfg.rendezvous),
     );
 

--- a/src/haven_util.rs
+++ b/src/haven_util.rs
@@ -1,4 +1,5 @@
 use std::{
+    net::SocketAddr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -107,12 +108,14 @@ impl RegisterHavenReq {
 /// forwards it back to the earnedil network.
 pub async fn haven_loop(ctx: DaemonContext, haven_cfg: HavenForwardConfig) -> anyhow::Result<()> {
     match haven_cfg.handler {
-        ForwardHandler::UdpForward { from_dock, to_port } => {
-            udp_forward(ctx, haven_cfg, from_dock, to_port).await
-        }
-        ForwardHandler::TcpForward { from_dock, to_port } => {
-            tcp_forward(ctx, haven_cfg, from_dock, to_port).await
-        }
+        ForwardHandler::UdpService {
+            listen: from_dock,
+            upstream,
+        } => udp_forward(ctx, haven_cfg, from_dock, upstream).await,
+        ForwardHandler::TcpService {
+            listen: from_dock,
+            upstream,
+        } => tcp_forward(ctx, haven_cfg, from_dock, upstream).await,
         ForwardHandler::SimpleProxy { listen_dock } => {
             simple_proxy(ctx, haven_cfg, listen_dock).await
         }
@@ -123,7 +126,7 @@ async fn udp_forward(
     ctx: DaemonContext,
     haven_cfg: HavenForwardConfig,
     from_dock: Dock,
-    to_port: u16,
+    upstream: SocketAddr,
 ) -> anyhow::Result<()> {
     // down loop forwards packets back down to the source Earendil endpoints
     async fn down_loop(
@@ -161,7 +164,7 @@ async fn udp_forward(
         let udp_socket = if let Some((socket, _)) = dmux_table.get(&src_endpoint) {
             socket
         } else {
-            let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await?);
+            let socket = Arc::new(UdpSocket::bind("0.0.0.0:0").await?);
             let down_task = Immortal::respawn(
                 smolscale::immortal::RespawnStrategy::Immediate,
                 clone!([earendil_skt, socket], move || {
@@ -173,9 +176,7 @@ async fn udp_forward(
             socket
         };
 
-        udp_socket
-            .send_to(&message, format!("127.0.0.1:{to_port}"))
-            .await?;
+        udp_socket.send_to(&message, upstream).await?;
     }
 }
 
@@ -183,7 +184,7 @@ async fn tcp_forward(
     ctx: DaemonContext,
     haven_cfg: HavenForwardConfig,
     from_dock: Dock,
-    to_port: u16,
+    upstream: SocketAddr,
 ) -> anyhow::Result<()> {
     let haven_id = IdentitySecret::from_seed(&haven_cfg.identity_seed);
     log::debug!(
@@ -204,7 +205,7 @@ async fn tcp_forward(
 
     loop {
         let earendil_stream = listener.accept().await?;
-        let tcp_stream = TcpStream::connect(format!("127.0.0.1:{to_port}")).await?;
+        let tcp_stream = TcpStream::connect(upstream).await?;
 
         log::debug!("TCP forward earendil stream accepted");
         reaper.attach(smolscale::spawn(async move {

--- a/src/haven_util.rs
+++ b/src/haven_util.rs
@@ -109,11 +109,11 @@ impl RegisterHavenReq {
 pub async fn haven_loop(ctx: DaemonContext, haven_cfg: HavenForwardConfig) -> anyhow::Result<()> {
     match haven_cfg.handler {
         ForwardHandler::UdpService {
-            listen: from_dock,
+            listen_dock: from_dock,
             upstream,
         } => udp_forward(ctx, haven_cfg, from_dock, upstream).await,
         ForwardHandler::TcpService {
-            listen: from_dock,
+            listen_dock: from_dock,
             upstream,
         } => tcp_forward(ctx, haven_cfg, from_dock, upstream).await,
         ForwardHandler::SimpleProxy { listen_dock } => {

--- a/src/socket/crypt_session.rs
+++ b/src/socket/crypt_session.rs
@@ -45,7 +45,7 @@ pub struct Handshake {
 impl CryptSession {
     pub fn new(
         my_isk: IdentitySecret,
-        remote_ep: Endpoint,
+        remote: Endpoint,
         rendezvous_fp: Option<Fingerprint>,
         n2r_skt: N2rSocket,
         send_incoming_decrypted: Sender<(Bytes, Endpoint)>,
@@ -64,7 +64,7 @@ impl CryptSession {
             enc_task(
                 my_isk,
                 n2r_skt,
-                remote_ep,
+                remote,
                 rendezvous_fp,
                 recv_in,
                 recv_out,
@@ -105,7 +105,7 @@ impl CryptSession {
 async fn enc_task(
     my_isk: IdentitySecret,
     n2r_skt: N2rSocket,
-    remote_ep: Endpoint,
+    remote: Endpoint,
     rendezvous_fp: Option<Fingerprint>,
     recv_incoming: Receiver<HavenMsg>,
     recv_outgoing: Receiver<Bytes>,
@@ -114,7 +114,7 @@ async fn enc_task(
     ctx: DaemonContext,
 ) -> anyhow::Result<Infallible> {
     let send_to_rendezvous = |msg: Bytes| async {
-        let fwd_body = (msg, remote_ep).stdcode();
+        let fwd_body = (msg, remote).stdcode();
         let rendezvous_ep = match rendezvous_fp {
             Some(rob) => {
                 // We're the server
@@ -123,7 +123,7 @@ async fn enc_task(
             None => {
                 // We're the client: look up Rob's addr in rendezvous dht
                 let bob_locator = ctx
-                    .dht_get(remote_ep.fingerprint)
+                    .dht_get(remote.fingerprint)
                     .timeout(Duration::from_secs(30))
                     .await
                     .map_or(
@@ -132,8 +132,8 @@ async fn enc_task(
                         )),
                         |res| res,
                     )
-                    .context(format!("DHT failed for {}", remote_ep.fingerprint))?
-                    .context(format!("DHT returned None for {}", remote_ep.fingerprint))?;
+                    .context(format!("DHT failed for {}", remote.fingerprint))?
+                    .context(format!("DHT returned None for {}", remote.fingerprint))?;
                 Endpoint::new(bob_locator.rendezvous_point, HAVEN_FORWARD_DOCK)
             }
         };
@@ -197,9 +197,7 @@ async fn enc_task(
             if let HavenMsg::Regular { nonce, inner } = msg {
                 if rf.add(nonce) {
                     let plain = dec_key.open(&pad_nonce(nonce), &inner)?;
-                    send_incoming_decrypted
-                        .send((plain.into(), remote_ep))
-                        .await?
+                    send_incoming_decrypted.send((plain.into(), remote)).await?
                 } else {
                     log::debug!("received pkt with duplicate nonce! dropping...")
                 }


### PR DESCRIPTION
This PR fixes some rather confusing names in the config YAML:

- Haven listening docks are now uniformly `listen_dock`
- Reverse-proxy upstreams are now called `upstream`, and are `SocketAddr`s rather than `u16`s
- Local TCP/UDP port-forwarding as well as SOCKS5 now listen to `SocketAddr`s rather than ports
- `remote_ep` has been renamed `remote`, since the `_ep` seems pretty redundant

