### PR TITLE
Switch next peeler to NodeAddr

### DIFF
--- a/libraries/earendil_packet/benches/benchmark.rs
+++ b/libraries/earendil_packet/benches/benchmark.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use earendil_crypt::{AnonEndpoint, RelayFingerprint, RemoteId};
+use earendil_topology::NodeAddr;
 use earendil_packet::{
     crypt::DhSecret, ForwardInstruction, InnerPacket, Message, PrivacyConfig, RawPacket, Surb,
 };
@@ -11,7 +12,7 @@ fn generate_forward_instructions(n: usize) -> Vec<(ForwardInstruction, DhSecret)
             let our_sk = DhSecret::generate();
             let this_pubkey = our_sk.public();
 
-            let next_hop = RelayFingerprint::from_bytes(&[10; 32]);
+            let next_hop = NodeAddr::new(RelayFingerprint::from_bytes(&[10; 32]), 0);
             (
                 ForwardInstruction {
                     this_pubkey,
@@ -59,7 +60,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             });
         });
 
-        let first_peeler = RelayFingerprint::from_bytes(&[10; 32]);
+        let first_peeler = NodeAddr::new(RelayFingerprint::from_bytes(&[10; 32]), 0);
 
         c.bench_function(
             &format!("{route_length}-hop ReplyBlock construction"),

--- a/libraries/earendil_packet/src/lib.rs
+++ b/libraries/earendil_packet/src/lib.rs
@@ -28,6 +28,7 @@ impl Default for PrivacyConfig {
 mod tests {
     use bytes::Bytes;
     use earendil_crypt::{AnonEndpoint, RelayFingerprint, RemoteId};
+    use earendil_topology::NodeAddr;
 
     use earendil_crypt::DhSecret;
 
@@ -39,7 +40,7 @@ mod tests {
                 let our_sk = DhSecret::generate();
                 let this_pubkey = our_sk.public();
 
-                let next_hop = RelayFingerprint::from_bytes(&[10; 32]);
+                let next_hop = NodeAddr::new(RelayFingerprint::from_bytes(&[10; 32]), 0);
                 (
                     ForwardInstruction {
                         this_pubkey,
@@ -154,7 +155,7 @@ mod tests {
             .iter()
             .map(|(inst, _)| *inst)
             .collect();
-        let first_peeler = RelayFingerprint::from_bytes(&[10; 32]);
+        let first_peeler = NodeAddr::new(RelayFingerprint::from_bytes(&[10; 32]), 0);
 
         // Prepare reply block
         let (reply_block, (_, reply_degarbler)) = Surb::new(

--- a/libraries/earendil_packet/src/reply_block.rs
+++ b/libraries/earendil_packet/src/reply_block.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use earendil_crypt::{AnonEndpoint, DhPublic, RelayFingerprint, RemoteId};
+use earendil_topology::NodeAddr;
 use rand::Rng;
 
 use serde::{Deserialize, Serialize};
@@ -14,13 +15,13 @@ use crate::{
 pub struct Surb {
     pub header: RawHeader,
     pub stream_key: [u8; 32],
-    pub first_peeler: RelayFingerprint,
+    pub first_peeler: NodeAddr,
 }
 
 impl Surb {
     pub fn new(
         route: &[ForwardInstruction],
-        first_peeler: RelayFingerprint,
+        first_peeler: NodeAddr,
         dest_opk: &DhPublic,
         my_anon_id: AnonEndpoint,
         privacy_cfg: PrivacyConfig,

--- a/libraries/earendil_topology/src/lib.rs
+++ b/libraries/earendil_topology/src/lib.rs
@@ -14,11 +14,13 @@ use earendil_crypt::{
 use indexmap::IndexMap;
 use rand::{Rng, seq::IteratorRandom, thread_rng};
 use serde::{Deserialize, Serialize};
+use bytemuck::{Pod, Zeroable};
 use stdcode::StdcodeSerializeExt;
 use thiserror::Error;
 
 /// Identifies a specific node in the network, which could be a relay or a client (client_id > 0)
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Pod, Zeroable)]
 pub struct NodeAddr {
     pub relay: RelayFingerprint,
     pub client_id: u64,
@@ -27,6 +29,14 @@ pub struct NodeAddr {
 impl NodeAddr {
     pub fn new(relay: RelayFingerprint, client_id: u64) -> Self {
         NodeAddr { relay, client_id }
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 40] {
+        bytemuck::cast_ref(self)
+    }
+
+    pub fn from_bytes(bytes: &[u8; 40]) -> Self {
+        *bytemuck::cast_ref(bytes)
     }
 }
 

--- a/src/link_node.rs
+++ b/src/link_node.rs
@@ -63,7 +63,7 @@ impl LinkNode {
             )?;
             Datagram {
                 ttl: u8::MAX,
-                dest_addr: NodeAddr::new(instructs.get(0).context("no first peeler")?.next_hop, 0),
+                dest_addr: instructs.get(0).context("no first peeler")?.next_hop,
                 payload: bytemuck::bytes_of(&raw_packet).to_vec().into(),
             }
         };
@@ -82,7 +82,7 @@ impl LinkNode {
             )?;
             let datagram = Datagram {
                 ttl: u8::MAX,
-                dest_addr: NodeAddr::new(reply_block.first_peeler, 0),
+                dest_addr: reply_block.first_peeler,
                 payload: bytemuck::bytes_of(&raw_packet).to_vec().into(),
             };
             self.lownet.send(datagram).await;
@@ -101,7 +101,7 @@ impl LinkNode {
     }
 
     /// Sends a raw packet.
-    async fn send_raw(&self, raw: RawPacket, next_peeler: RelayFingerprint) {
+    async fn send_raw(&self, raw: RawPacket, next_peeler: NodeAddr) {
         todo!()
     }
 

--- a/src/link_node/link.rs
+++ b/src/link_node/link.rs
@@ -2,7 +2,7 @@ use std::{ops::DerefMut, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use earendil_crypt::RelayFingerprint;
+use earendil_topology::NodeAddr;
 use futures::{
     io::{ReadHalf, WriteHalf},
     AsyncBufReadExt,
@@ -133,7 +133,7 @@ impl RpcTransport for MuxRpcTransport {
 pub enum LinkMessage {
     ToRelay {
         packet: Bytes,
-        next_peeler: RelayFingerprint,
+        next_peeler: NodeAddr,
     },
     ToClient {
         body: Bytes,


### PR DESCRIPTION
## Summary
- add `Pod` support to `NodeAddr`
- use `NodeAddr` for hop metadata
- store `NodeAddr` in reply blocks
- update packet peeling logic
- adjust link and route utilities for the new type

## Testing
- `cargo build -q --offline`
- `cargo test -q --offline`