### PR TITLE
Generic control CLI

### DIFF
--- a/src/bin/earendil.rs
+++ b/src/bin/earendil.rs
@@ -59,8 +59,10 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Control {
             connect,
-            control_command,
-        } => smolscale::block_on(main_control(control_command, connect)),
+            json,
+            method,
+            args,
+        } => smolscale::block_on(main_control(method, args, json, connect)),
         Commands::GenerateSeed => {
             let seed_phrase = gen_seed()?;
             println!("{seed_phrase}");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,6 @@
 use std::{net::SocketAddr, path::PathBuf};
 
-use clap::{Subcommand, arg};
-use earendil_crypt::{HavenFingerprint, RelayFingerprint};
+use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub enum Commands {
@@ -15,8 +14,13 @@ pub enum Commands {
     Control {
         #[arg(short, long, default_value = "127.0.0.1:18964")]
         connect: SocketAddr,
-        #[command(subcommand)]
-        control_command: ControlCommand,
+        /// Output raw JSON instead of pretty YAML
+        #[arg(long)]
+        json: bool,
+        /// Method on the control protocol to invoke
+        method: String,
+        /// Arguments to the method, expressed as YAML values
+        args: Vec<String>,
     },
 
     /// Runs a control-protocol verb.
@@ -29,44 +33,6 @@ pub enum Commands {
     GenerateSeed,
 }
 
-#[derive(Subcommand)]
-pub enum ControlCommand {
-    /// Prints the information of all hosted havens
-    HavensInfo,
-
-    /// Send a GlobalRpc request to a destination.
-    GlobalRpc {
-        #[arg(long)]
-        id: Option<String>,
-        #[arg(short, long)]
-        dest: RelayFingerprint,
-        #[arg(short, long)]
-        method: String,
-        args: Vec<String>,
-    },
-
-    /// Insert a rendezvous haven locator into the dht.
-    InsertRendezvous {
-        #[arg(short, long)]
-        identity_sk: String,
-        #[arg(short, long)]
-        onion_pk: String,
-        #[arg(short, long)]
-        rendezvous_fingerprint: RelayFingerprint,
-    },
-
-    /// Looks up a rendezvous haven locator.
-    GetRendezvous {
-        #[arg(short, long)]
-        key: HavenFingerprint,
-    },
-
-    /// Dumps the relay graph in graphviz format.
-    RelayGraphviz,
-
-    /// Dumps my own routes.
-    MyRoutes,
-}
 
 #[derive(Subcommand)]
 pub enum ChatCommand {


### PR DESCRIPTION
## Summary
- add a generic `Control` command that accepts a method name and YAML args
- refactor control client to call arbitrary methods and format output

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_b_686d68ebba588333b17bbdffc1f4098a